### PR TITLE
add support for .ply files output by modern OpenSfM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(FPCFilter VERSION 0.1 LANGUAGES CXX)
+project(FPCFilter VERSION 0.2 LANGUAGES CXX)
 
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ property uchar views
 end_header
 ```
 
+or 
+
+```
+property float x
+property float y
+property float z
+property uchar red
+property uchar green
+property uchar blue
+property uchar views
+end_header
+```
+
 **FPCFilter** outputs a `binary little endian` PLY with the following header if the source has the normals (`nx`, `ny`, `nz`):
 
 ```

--- a/fastoutlierfilter.hpp
+++ b/fastoutlierfilter.hpp
@@ -105,7 +105,7 @@ namespace FPCFilter {
             std::vector<double> sqr_dists;
             size_t SAMPLES = std::min<size_t>(np, 10000);
 
-            size_t count = 2;
+            size_t count = 3;
             std::vector<double> distances(SAMPLES, 0.0);
 
             std::unordered_map<uint64_t, size_t> dist_map;

--- a/fastoutlierfilter.hpp
+++ b/fastoutlierfilter.hpp
@@ -277,10 +277,10 @@ namespace FPCFilter {
                 }
             }
 
-            double density = static_cast<double>(d) / 100.0;
-            (*stats)["density"] = density;
+            double spacing = static_cast<double>(d) / 100.0;
+            (*stats)["spacing"] = spacing;
 
-            std::cout << " -> Density estimation completed (" << density << " meters)" << std::endl << std::endl;
+            std::cout << " -> Spacing estimation completed (" << spacing << " meters)" << std::endl << std::endl;
             
         }
 

--- a/fastsamplefilter.hpp
+++ b/fastsamplefilter.hpp
@@ -105,12 +105,6 @@ namespace FPCFilter {
 
     private:
 
-        inline int fast_floor(double x)
-        {
-            int i = (int)x; /* truncate */
-            return i - ( i > x ); /* convert trunc to floor */
-        }
-
         bool safe_voxelize(const PlyPoint& point) {
 
             double x = point.x;
@@ -118,9 +112,9 @@ namespace FPCFilter {
             double z = point.z;
 
             // Get voxel indices for current point.
-            auto v = Voxel(fast_floor((x - originX) / cell), 
-                           fast_floor((y - originY) / cell), 
-                           fast_floor((z - originZ) / cell));
+            auto v = Voxel(static_cast<int>(std::floor((x - originX) / cell)), 
+                           static_cast<int>(std::floor((y - originY) / cell)), 
+                           static_cast<int>(std::floor((z - originZ) / cell)));
 
             // Check current voxel before any of the neighbors. We will most often have
             // points that are too close in the point's enclosing voxel, thus saving

--- a/main.cpp
+++ b/main.cpp
@@ -17,6 +17,9 @@ int main(const int argc, char** argv)
         std::cout << "\tinput = " << parameters.input << std::endl;
         std::cout << "\toutput = " << parameters.output << std::endl;
 
+		if (!parameters.stats.empty()) std::cout << "\tstats = " << parameters.stats << std::endl;
+		nlohmann::json stats = nlohmann::json::object();
+
 		if (parameters.std.has_value())
 			std::cout << "\tstd = " << std::setprecision(4) << parameters.std.value() << std::endl;
 		if (parameters.radius.has_value())
@@ -38,7 +41,7 @@ int main(const int argc, char** argv)
 
 		const auto pipelineStart = std::chrono::steady_clock::now();
 
-		FPCFilter::Pipeline pipeline(parameters.input, std::cout, parameters.verbose);
+		FPCFilter::Pipeline pipeline(parameters.input, std::cout, parameters.verbose, &stats);
 
 		if (parameters.isCropRequested)
 		{
@@ -106,6 +109,11 @@ int main(const int argc, char** argv)
 
 		std::cout << std::endl << " ?> Pipeline done in " << pipelineDiff.count() << "s" << std::endl << std::endl;
 
+		if (!parameters.stats.empty()){
+			std::ofstream o(parameters.stats);
+			o << stats;
+			o.close();
+		}
 	}
 	catch(const std::invalid_argument& e) {
 		std::cerr << e.what() << std::endl;

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -124,7 +124,7 @@ namespace FPCFilter
 				if (meank < 1)
 					throw std::invalid_argument("Mean number of neighbors cannot be less than 1");
 
-				isFilterRequested = true;
+				isFilterRequested = std > 0 && meank > 1;
 			}
 
 			if (result.count("radius")) {

--- a/parameters.hpp
+++ b/parameters.hpp
@@ -57,6 +57,7 @@ namespace FPCFilter
 	public:
 		std::string input;
 		std::string output;
+		std::string stats;
 		
 		bool isCropRequested = false;
 		std::optional<Polygon> boundary;
@@ -81,6 +82,7 @@ namespace FPCFilter
 			options.add_options()
 				("i,input", "Input point cloud", cxxopts::value<std::string>())
 				("o,output", "Output point cloud", cxxopts::value<std::string>())
+				("j,stats", "Output statistics file (JSON)", cxxopts::value<std::string>())
 				("b,boundary", "Crop boundary (GeoJSON POLYGON)", cxxopts::value<std::string>())
 				("s,std", "Standard deviation threshold", cxxopts::value<double>())
 				("m,meank", "Mean number of neighbors", cxxopts::value<int>())
@@ -107,6 +109,8 @@ namespace FPCFilter
 
 			if (output.empty())
 				throw std::invalid_argument("Output file is empty");
+
+			stats = result.count("stats") ? result["stats"].as<std::string>() : "";
 
 			if (result.count("std") && result.count("meank")) {
 

--- a/pipeline.hpp
+++ b/pipeline.hpp
@@ -31,9 +31,11 @@ namespace FPCFilter
 		std::string source;
 		bool isLoaded = false;
 		bool isVerbose = false;
+		nlohmann::json *stats;
 
 	public:
-		Pipeline(const std::string &source, std::ostream& logstream, const bool verbose) : source(source), isVerbose(verbose), log(logstream) {}
+		Pipeline(const std::string &source, std::ostream& logstream, const bool verbose, nlohmann::json *stats) : 
+			source(source), isVerbose(verbose), log(logstream), stats(stats) {}
 
 		void load()
 		{
@@ -87,7 +89,7 @@ namespace FPCFilter
 			if (!this->isLoaded)
 				this->load();
 
-			FastOutlierFilter filter(std, meank, this->log, this->isVerbose);
+			FastOutlierFilter filter(std, meank, this->log, this->isVerbose, stats);
 
 			filter.run(*this->ply);
 		}

--- a/ply.hpp
+++ b/ply.hpp
@@ -128,16 +128,16 @@ namespace FPCFilter {
 					throw std::invalid_argument("Invalid PLY file (expected 'property float z')");
 
 				std::getline(reader, line);
-				if (line != "property uchar diffuse_red")
-					throw std::invalid_argument("Invalid PLY file (expected 'property uchar diffuse_red')");
+				if (line != "property uchar diffuse_red" && line != "property uchar red")
+					throw std::invalid_argument("Invalid PLY file (expected 'property uchar diffuse_red' or 'property uchar red')");
 
 				std::getline(reader, line);
-				if (line != "property uchar diffuse_green")
-					throw std::invalid_argument("Invalid PLY file (expected 'property uchar diffuse_green')");
+				if (line != "property uchar diffuse_green" && line != "property uchar green")
+					throw std::invalid_argument("Invalid PLY file (expected 'property uchar diffuse_green' or 'property uchar green')");
 
 				std::getline(reader, line);
-				if (line != "property uchar diffuse_blue")
-					throw std::invalid_argument("Invalid PLY file (expected 'property uchar diffuse_blue')");
+				if (line != "property uchar diffuse_blue" && line != "property uchar blue")
+					throw std::invalid_argument("Invalid PLY file (expected 'property uchar diffuse_blue' or 'property uchar blue')");
 
 				std::getline(reader, line);
 				if (line != "property uchar views")


### PR DESCRIPTION
In https://github.com/mapillary/OpenSfM/commit/cb1fdeeac280f4b32e52f7300506b4831f23ce8f, OpenSfM's .ply output was changed to use `property uchar red` instead of `property uchar diffuse_red`.

This PR updates FPCFilter to support both old and new formats.

This PR also includes all changes from `331` branch.